### PR TITLE
feat: use cookie consent to specify using matomo cookies

### DIFF
--- a/.github/workflows/pack-plugin.yml
+++ b/.github/workflows/pack-plugin.yml
@@ -1,0 +1,60 @@
+name: PackPlugin
+on:
+    push:
+        branches:
+            - '*'
+        tags:
+            - '*'
+
+env:
+    PLUGIN_NAME: JinyaMatomo
+
+jobs:
+    CreateZip:
+        runs-on: ubuntu-latest
+        container: ghcr.io/friendsofshopware/platform-plugin-dev:v6.3.2
+        steps:
+            -   name: Get the version
+                id: get_version
+                run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+            -   name: Checkout
+                uses: actions/checkout@v2.3.1
+                with:
+                    path: ${{ env.PLUGIN_NAME }}
+
+            -   name: Build & create zip
+                run: |
+                    cp -r "./${PLUGIN_NAME}" "/plugins/${PLUGIN_NAME}"
+                    start-mysql
+                    pack-plugin "${PLUGIN_NAME}"
+
+            -   name: Upload Artefact
+                uses: actions/upload-artifact@v2
+                with:
+                    name: ${{ env.PLUGIN_NAME }}
+                    path: ${{ env.PLUGIN_NAME }}.zip
+
+            -   name: Create Release in github
+                if: startsWith(github.ref, 'refs/tags/')
+                id: create_release
+                uses: actions/create-release@v1.0.0
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                with:
+                    tag_name: ${{ steps.get_version.outputs.VERSION }}
+                    release_name: ${{ steps.get_version.outputs.VERSION }}
+                    draft: false
+                    prerelease: false
+
+            -   name: Upload Release Asset to github
+                if: startsWith(github.ref, 'refs/tags/')
+                id: upload_release_asset
+                uses: actions/upload-release-asset@v1.0.2
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                with:
+                    upload_url: ${{ steps.create_release.outputs.upload_url }}
+                    asset_path: ${{ env.PLUGIN_NAME }}.zip
+                    asset_name: ${{ env.PLUGIN_NAME }}.zip
+                    asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+jinya-matomo.js

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "jinya/matomo-shopware-plugin",
+  "version": "0.0.1",
   "description": "Matomo plugin for shopware 6",
   "type": "shopware-platform-plugin",
   "license": "MIT",
@@ -7,6 +8,9 @@
     "psr-4": {
       "JinyaMatomo\\": "src/"
     }
+  },
+  "require": {
+    "shopware/core": "~6.3.0"
   },
   "extra": {
     "shopware-plugin-class": "JinyaMatomo\\JinyaMatomo",

--- a/src/Resources/app/storefront/src/main.js
+++ b/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,9 @@
+import MatomoAnalyticsPlugin from "./plugin/MatomoAnalyticsPlugin";
+
+// Necessary for the webpack hot module reloading server
+if (module.hot) {
+    module.hot.accept();
+}
+
+window.PluginManager.register('MatomoAnalytics', MatomoAnalyticsPlugin);
+

--- a/src/Resources/app/storefront/src/plugin/MatomoAnalyticsPlugin.js
+++ b/src/Resources/app/storefront/src/plugin/MatomoAnalyticsPlugin.js
@@ -1,0 +1,52 @@
+import Plugin from "src/plugin-system/plugin.class";
+import CookieStorageHelper from "src/helper/storage/cookie-storage.helper";
+import {COOKIE_CONFIGURATION_UPDATE} from "src/plugin/cookie/cookie-configuration.plugin";
+
+export default class MatomoAnalyticsPlugin extends Plugin {
+    init() {
+        this.cookieEnabledName = 'matomo-analytics-enabled';
+        window.matomoCookieActive = Boolean(CookieStorageHelper.getItem(this.cookieEnabledName));
+
+        this.startMatomoAnalytics();
+    }
+
+    startMatomoAnalytics() {
+        window.mTrackCall();
+    }
+
+    handleCookieChangeEvent() {
+        document.$emitter.subscribe(COOKIE_CONFIGURATION_UPDATE, this.handleCookies.bind(this));
+    }
+
+    handleCookies(cookieUpdateEvent) {
+        const updatedCookies = cookieUpdateEvent.detail;
+
+        if (!Object.prototype.hasOwnProperty.call(updatedCookies, this.cookieEnabledName)) {
+            return;
+        }
+
+        if (updatedCookies[this.cookieEnabledName]) {
+            return;
+        }
+
+        this.removeCookies();
+    }
+
+    removeCookies() {
+        if (!CookieStorageHelper.isSupported()) {
+            return;
+        }
+
+        const allCookies = document.cookie.split(';');
+        const gaCookieRegex = /^(_pk)/;
+
+        allCookies.forEach(cookie => {
+            const cookieName = cookie.split('=')[0].trim();
+            if (!cookieName.match(gaCookieRegex)) {
+                return;
+            }
+
+            CookieStorageHelper.removeItem(cookieName);
+        });
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="JinyaMatomo\Service\CustomCookieProvider"
+                 decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
+            <argument type="service" id="JinyaMatomo\Service\CustomCookieProvider.inner" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/snippet/messages.de-DE.json
+++ b/src/Resources/snippet/messages.de-DE.json
@@ -1,0 +1,6 @@
+{
+  "cookie": {
+    "MatomoAnalytics": "Matomo Analytics",
+    "MatomoDescription": ""
+  }
+}

--- a/src/Resources/snippet/messages.en-GB.json
+++ b/src/Resources/snippet/messages.en-GB.json
@@ -1,0 +1,6 @@
+{
+  "cookie": {
+    "MatomoAnalytics": "Matomo Analytics",
+    "MatomoDescription": ""
+  }
+}

--- a/src/Resources/snippet/messages.fr-FR.json
+++ b/src/Resources/snippet/messages.fr-FR.json
@@ -1,0 +1,6 @@
+{
+  "cookie": {
+    "MatomoAnalytics": "Matomo Analytics",
+    "MatomoDescription": ""
+  }
+}

--- a/src/Resources/snippet/messages.nl-NL.json
+++ b/src/Resources/snippet/messages.nl-NL.json
@@ -1,0 +1,6 @@
+{
+  "cookie": {
+    "MatomoAnalytics": "Matomo Analytics",
+    "MatomoDescription": ""
+  }
+}

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -3,39 +3,37 @@
     {{ parent() }}
     <script>
         window._paq = window._paq || [];
+
         {% if activeRoute == "frontend.detail.page" %}
-        window._paq.push([
-            'setEcommerceView',
-            '{{ page.product.productNumber|escape('js') }}',
-            '{{ page.product.name|escape('js') }}',
-            ''
-        ]);
+            window._paq.push([
+                'setEcommerceView',
+                '{{ page.product.productNumber|escape('js') }}',
+                '{{ page.product.name|escape('js') }}',
+                ''
+            ]);
         {% endif %}
 
         {% if page.order is defined %}
-        {% for item in page.order.lineItems.elements %}
+            {% for item in page.order.lineItems.elements %}
+                window._paq.push([
+                    'addEcommerceItem',
+                    '{{ item.payload["productNumber"] }}',
+                    '{{ item.label }}',
+                    '',
+                    {{ item.totalPrice }},
+                    '{{ item.quantity }}',
+                ]);
+            {% endfor %}
             window._paq.push([
-                'addEcommerceItem',
-                '{{ item.payload["productNumber"] }}',
-                '{{ item.label }}',
-                '',
-                {{ item.totalPrice }},
-                '{{ item.quantity }}',
+                'trackEcommerceOrder',
+                '{{ page.order.orderNumber }}',
+                {{ page.order.amountTotal }},
+                {{ page.order.positionPrice }},
+                {{ page.order.amountTotal - page.order.amountNet }},
+                {{ page.order.shippingTotal }},
+                false
             ]);
-        {% endfor %}
-        window._paq.push([
-            'trackEcommerceOrder',
-            '{{ page.order.orderNumber }}',
-            {{ page.order.amountTotal }},
-            {{ page.order.positionPrice }},
-            {{ page.order.amountTotal - page.order.amountNet }},
-            {{ page.order.shippingTotal }},
-            false
-        ]);
         {% endif %}
-        window._paq.push(["disableCookies"]);
-        window._paq.push(['trackPageView']);
-        window._paq.push(['enableLinkTracking']);
 
         {% if shopware.config.JinyaMatomo.config.phpTrackingPath is defined %}
             {% set phpTrackingPath = shopware.config.JinyaMatomo.config.phpTrackingPath %}
@@ -49,11 +47,18 @@
             {% set jsTrackingPath = 'matomo.js' %}
         {% endif %}
 
+        window.mTrackCall = function() {
+            if (!window.matomoCookieActive) {
+                window._paq.push(["disableCookies"]);
+            }
+            window._paq.push(['trackPageView']);
+            window._paq.push(['enableLinkTracking']);
+        }
+
         {% if shopware.config.JinyaMatomo.config.matomoserver %}
             const u = '//{{ shopware.config.JinyaMatomo.config.matomoserver }}/';
-
-            _paq.push(['setTrackerUrl', u + '{{ phpTrackingPath }}']);
-            _paq.push(['setSiteId', '{{ shopware.config.JinyaMatomo.config.matomosite }}']);
+            window._paq.push(['setTrackerUrl', u + '{{ phpTrackingPath }}']);
+            window._paq.push(['setSiteId', '{{ shopware.config.JinyaMatomo.config.matomosite }}']);
             (function () {
                 const d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
                 g.type = 'text/javascript';

--- a/src/Service/CustomCookieProvider.php
+++ b/src/Service/CustomCookieProvider.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace JinyaMatomo\Service;
+
+use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+
+class CustomCookieProvider implements CookieProviderInterface {
+
+    private $originalService;
+
+    public function __construct(CookieProviderInterface $service)
+    {
+        $this->originalService = $service;
+    }
+
+    private const cookieGroup = [
+        'snippet_name' => 'cookie.groupStatistical',
+        'snippet_description' => 'cookie.groupStatisticalDescription',
+        'entries' => [
+            [
+                'snippet_name' => 'cookie.MatomoAnalytics',
+                'snippet_description' => 'cookie.MatomoDescription',
+                'cookie' => 'matomo-analytics-enabled',
+                'expiration' => '30',
+                'value' => '1',
+            ]
+        ],
+    ];
+
+    public function getCookieGroups(): array
+    {
+        $cookieGroups = $this->originalService->getCookieGroups();
+
+        foreach ($cookieGroups as $key => $group) {
+            if ($group['snippet_name'] === self::cookieGroup['snippet_name']) {
+                $cookieGroups[$key]['entries'] = array_merge(
+                    $group['entries'], self::cookieGroup['entries']
+                );
+                return $cookieGroups;
+            }
+        }
+
+        return array_merge(
+            $cookieGroups,
+            [
+                self::cookieGroup
+            ]
+        );
+    }
+}


### PR DESCRIPTION
I've added the cookie consent minimally invasive :-)

`cookie.MatomoDescription` should give the ability to specify a short user-friendly test, f.e.: we are self-hosted, no data selling, ......

Additionally, I've added an action to create releases. Could you please register this repository to packagist.org and then creating a tag?
Tagging will automatically build and publish a release on github.